### PR TITLE
[CRDES-45750] Subscribe to pay_events EventChannel on Android only

### DIFF
--- a/pay_platform_interface/lib/pay_channel.dart
+++ b/pay_platform_interface/lib/pay_channel.dart
@@ -15,6 +15,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
 import 'core/payment_configuration.dart';
@@ -41,14 +42,22 @@ class PayMethodChannel extends PayPlatform {
   final StreamController<Map<String, dynamic>> _eventStreamController = StreamController.broadcast();
 
   PayMethodChannel() {
-    // Listen to the event channel and add events to the stream controller
-    _eventChannel.receiveBroadcastStream().listen((dynamic event) {
-      final Map<String, dynamic> eventData = jsonDecode(event as String) as Map<String, dynamic>;
-      _eventStreamController.add(eventData);
-    }, onError: (dynamic error) {
-      // Flush error to the event stream controller
-      _eventStreamController.addError('[PayMethodChannel] Error receiving event: $error');
-    });
+    // The `pay_events` EventChannel is only implemented on the Android side of
+    // the plugin (pay_android). iOS registers no handler for it, so subscribing
+    // on iOS throws MissingPluginException on every PayMethodChannel creation
+    // (CRDES-45750). Only Android delivers the payment result over this stream;
+    // iOS reads it directly from showPaymentSelector, so skipping the
+    // subscription there is a no-op behaviourally.
+    if (defaultTargetPlatform == TargetPlatform.android) {
+      // Listen to the event channel and add events to the stream controller
+      _eventChannel.receiveBroadcastStream().listen((dynamic event) {
+        final Map<String, dynamic> eventData = jsonDecode(event as String) as Map<String, dynamic>;
+        _eventStreamController.add(eventData);
+      }, onError: (dynamic error) {
+        // Flush error to the event stream controller
+        _eventStreamController.addError('[PayMethodChannel] Error receiving event: $error');
+      });
+    }
   }
 
   /// Provides a stream of payment events.


### PR DESCRIPTION
## Problem
`PayMethodChannel`'s constructor unconditionally subscribes to the `plugins.flutter.io/pay_events` EventChannel. That channel is only implemented on the Android side of the plugin (`pay_android`); the iOS plugin registers no handler for it. As a result, every `Pay()` creation on iOS throws `MissingPluginException(No implementation found for method listen on channel plugins.flutter.io/pay_events)`.

In the consuming app (Plazo Card ES) this is a very high-volume non-fatal on iOS (10.8k users / 42k events) and also surfaces as a fatal SIGABRT via Kotlin/Native — Jira CRDES-45750.

## Fix
Guard the event-channel subscription with `defaultTargetPlatform == TargetPlatform.android`.

- Only Android pushes the payment result over `pay_events`; iOS reads the result directly from `showPaymentSelector`, so it never listens to `events`. Skipping the subscription on iOS is therefore a behavioural no-op.
- Google Pay on Android is unaffected — the subscription still runs there exactly as before.

## Testing
- `flutter analyze` — no new issues (only pre-existing `avoid_annotating_with_dynamic` infos on the untouched callback params).
- `flutter test` (pay_platform_interface) — all pass; `showPaymentSelector` / `userCanPay` channel I/O tests run under the default Android test platform, so the Android subscription path stays covered.
- Manual QA on the consuming app: iOS no longer logs `MissingPluginException ... pay_events`; Apple Pay availability/flow unchanged; Android Google Pay still completes end-to-end.
